### PR TITLE
Compatibility to Rails >= 6.0, < 8.0

### DIFF
--- a/double_entry.gemspec
+++ b/double_entry.gemspec
@@ -46,9 +46,9 @@ Please note the following changes in DoubleEntry:
 POSTINSTALLMESSAGE
 
   gem.add_dependency 'money',                 '>= 6.0.0'
-  gem.add_dependency 'activerecord',          '>= 3.2.0'
-  gem.add_dependency 'activesupport',         '>= 3.2.0'
-  gem.add_dependency 'railties',              '>= 3.2.0'
+  gem.add_dependency 'activerecord',          '>= 6.0.0', '< 8.0'
+  gem.add_dependency 'activesupport',         '>= 6.0.0', '< 8.0'
+  gem.add_dependency 'railties',              '>= 6.0.0', '< 8.0'
 
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'mysql2'

--- a/lib/double_entry/line_metadata.rb
+++ b/lib/double_entry/line_metadata.rb
@@ -13,6 +13,11 @@ module DoubleEntry
     end
 
     belongs_to :line
-    serialize :key, SymbolWrapper
+
+    if Rails.gem_version >= '7.1.0'
+      serialize :key, coder: SymbolWrapper
+    else
+      serialize :key, SymbolWrapper
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 require 'bundler/setup'
 require 'active_record'
-require 'active_support'
+require 'active_support/all'
 
 if ActiveRecord::VERSION::MAJOR < 4
   require 'test-unit'


### PR DESCRIPTION
Rails 7.1 requires ActiveRecord's `serialize` to use the keyword argument `coder` or `type` instead of a regular second argument.